### PR TITLE
Update PlayerActivity.java

### DIFF
--- a/A068MP3PlayerST/app/src/main/java/com/example/a068mp3playerst/PlayerActivity.java
+++ b/A068MP3PlayerST/app/src/main/java/com/example/a068mp3playerst/PlayerActivity.java
@@ -532,7 +532,8 @@ public class PlayerActivity extends AppCompatActivity {
 
         // Zeilenweises Lesen, Einsortieren der Einträge in eine Liste.
         // Lies unbedingt //https://stackoverflow.com/questions/1096621/read-string-line-by-line
-        String[] lines = subsText.split("\n");  // TODO: Fit machen für viele Zeilenumbruch-Varianten!
+        String sourceTextEol = "(<br>)";    // Im ID3v2 Tag muss nun "<br>" anstelle Newline "\n" stehen!
+        String[] lines = subsText.split(sourceTextEol);
         Log.i(TAG, "SubtitleData Lines=" + lines.length);
         //tvSubtitle.setText("SubtitleData Lines=" + lines.length);  //Test
         String txt = "";


### PR DESCRIPTION
In the TCOM (Composer) frame of  the ID3v2 tag newlines are not allowed. So in this experimental player the TCOM frame must contain the SRT data with no newlines, but '<br>' instead. The string read is split by '<br>' at code line 536. Try the player with a suitable MP3 file!